### PR TITLE
Fix YAML indentation and key casing errors

### DIFF
--- a/lesson-storage/gke-volpod.yml
+++ b/lesson-storage/gke-volpod.yml
@@ -5,16 +5,16 @@ metadata:
 spec:
   volumes:
     - name: data
-    persistentVolumeClaim:
-      claimName: pvc1
-containers:
-  - name: ubuntu-ctr
-    image: ubuntu:latest
-    command:
-    - /bin/bash
-    - "-c"
-    - "sleep 60m"
-    imagePullPolicy: IfNotPresent
-    volumeMounts:
-    - mountpath: /data
-      name: data
+      persistentVolumeClaim:
+        claimName: pvc1
+  containers:
+    - name: ubuntu-ctr
+      image: ubuntu:latest
+      command:
+        - /bin/bash
+        - "-c"
+        - "sleep 60m"
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - mountPath: /data
+          name: data


### PR DESCRIPTION
The YAML indentation in the existing file is invalid and can't be processed by kubectl apply.  In addition, the key "mountPath" is incorrectly cased as "mountpath".

Those problems fixed in this proposed change.